### PR TITLE
Fixed Missing required parameters for [Route: documents.files.create] [URI: admin/files-upload/{id}].

### DIFF
--- a/resources/views/home.blade.php
+++ b/resources/views/home.blade.php
@@ -4,7 +4,7 @@
     <script>
         function gotoUpload() {
             var docId = $("#document_id").val();
-            var urlToUp = '{{route('documents.files.create',['id'=>''])}}'+'/'+docId;
+            var urlToUp = "{{route('documents.files.create', '')}}"+"/"+docId;
             console.log(urlToUp);
             window.location.href = urlToUp;
             return false;


### PR DESCRIPTION
var urlToUp = '{{route('documents.files.create',['id'=>''])}}'+'/'+docId;

In the above id is required param, but in the above code it was null. So in the case pass the empty string in place of route parameter to by pass the required validation.
For Ex. 

var urlToUp = "{{route('documents.files.create', '')}}"+"/"+docId;

![Screenshot (2)](https://user-images.githubusercontent.com/35896275/95664081-157ac500-0b62-11eb-8890-2551f5d59c05.png)
![Screenshot (3)](https://user-images.githubusercontent.com/35896275/95664082-16abf200-0b62-11eb-8693-d4f542ff1d3d.png)



